### PR TITLE
chore(opendistro-es): migrate ingress to networking.k8s.io/v1 API ver…

### DIFF
--- a/beeinventor/opendistro-es/Chart.yaml
+++ b/beeinventor/opendistro-es/Chart.yaml
@@ -26,4 +26,4 @@ name: opendistro-es
 sources:
 - https://pages.git.viasat.com/ATG/charts
 # Chart version
-version: 1.14.0
+version: 1.15.0

--- a/beeinventor/opendistro-es/templates/elasticsearch/es-client-ingress.yaml
+++ b/beeinventor/opendistro-es/templates/elasticsearch/es-client-ingress.yaml
@@ -16,13 +16,7 @@
 {{ $fullName := printf "%s-%s"  (include "opendistro-es.fullname" .) "client-service" }}
 {{ $ingressPath := .Values.elasticsearch.client.ingress.path }}
 kind: Ingress
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion }}
-apiVersion: extensions/v1beta1
-{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
-apiVersion: networking.k8s.io/v1beta1
-{{- else }}
 apiVersion: networking.k8s.io/v1
-{{- end }}
 metadata:
   name: {{ $fullName }}
   labels:
@@ -48,8 +42,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}

--- a/beeinventor/opendistro-es/templates/kibana/kibana-ingress.yml
+++ b/beeinventor/opendistro-es/templates/kibana/kibana-ingress.yml
@@ -16,14 +16,8 @@
 {{- $serviceName := printf "%s-%s" (include "opendistro-es.fullname" .) "kibana-svc" }}
 {{- $servicePort := .Values.kibana.externalPort }}
 {{- $ingressPath := .Values.kibana.ingress.path }}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion }}
-apiVersion: extensions/v1beta1
-{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
-apiVersion: networking.k8s.io/v1beta1
-{{- else }}
-apiVersion: networking.k8s.io/v1
-{{- end }}
 kind: Ingress
+apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ template "opendistro-es.fullname" . }}-kibana-ing
   labels:
@@ -39,9 +33,12 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
     {{- end }}
   {{- if .Values.kibana.ingress.tls }}
   tls: {{ toYaml .Values.kibana.ingress.tls | nindent 4 }}


### PR DESCRIPTION
BREAKING CHANGE: remove extensions/v1beta1 and networking.k8s.io/v1beta1 API versions support.