### PR TITLE
chore: upgrade GitHub Actions dependencies

### DIFF
--- a/.github/workflows/lint-helm.yaml
+++ b/.github/workflows/lint-helm.yaml
@@ -14,9 +14,9 @@ jobs:
   lint-helm:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Setup Helm
-      uses: azure/setup-helm@v1
+      uses: azure/setup-helm@v5
       with:
         version: "3.5.4"
     - name: Lint nsq

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -7,10 +7,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Publish Helm charts
-        uses: stefanprodan/helm-gh-pages@master
+        uses: stefanprodan/helm-gh-pages@v1.7.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           charts_dir: beeinventor
-


### PR DESCRIPTION
## Summary

- upgrade GitHub Actions dependency versions
- replace deprecated workflow helpers where needed
- keep workflow behavior unchanged

## Notes

- generated from the prepared local branch under `/Users/ike/Code/github.com/beeinventor.com/github-actions`
