### PR TITLE
chore(nsq): bump version to 1.3.0

### DIFF
--- a/beeinventor/nsq/Chart.yaml
+++ b/beeinventor/nsq/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nsq
 description: A realtime distributed messaging platform
 type: application
-version: 1.2.7
-appVersion: 1.2.1
+version: 1.3.0
+appVersion: 1.3.0
 home: https://github.com/beeinventor/charts/tree/master/beeinventor/nsq
 icon: https://nsq.io/static/img/nsq_blue.png
 keywords:


### PR DESCRIPTION
## NSQ upgrade notes

  This bumps the BeeInventor NSQ Helm chart from `1.2.7` to `1.3.0`. The underlying NSQ app
  image moves from `nsqio/nsq:v1.2.1` to `nsqio/nsq:v1.3.0`.

  Upstream NSQ `v1.3.0` changelog highlights:
  - Build/source maintenance: removes older `gobindata` / Go 1.16 support.
  - `nsqd`: adds TLS root CA usage for nsqauth requests.
  - `nsqd`: adds Unix socket listener support for TCP/HTTP/HTTPS.
  - `nsqd`: adds `/debug/freememory`, richer `/info`, TLS 1.3 support, optional HTTP/HTTPS
  listener disabling, and related fixes.
  - `nsqadmin`: updates frontend JS support to ES2020, adds paused-topic labeling, and fixes
  UI graph/counter issues.
  - Bug fixes include Dockerfile cleanup, dependency updates, nsqd concurrency fixes, and
  statsd/memstats panic fixes.

  Source: https://github.com/nsqio/nsq/releases/tag/v1.3.0

  ## Why no values changes

  No `values.yaml` change is needed for this chart bump.

  The chart already leaves `image.tag` unset, and the templates default the runtime image tag
  from `.Chart.AppVersion`, so bumping `appVersion` to `1.3.0` automatically renders `nsqio/
  nsq:v1.3.0`. Pinning `image.tag` in values would duplicate the same version and create
  future drift risk.

  The NSQ `v1.3.0` changes are either build-time maintenance, bug fixes, or optional runtime
  features behind new flags. Our existing chart values do not configure those optional flags,
  and the current ports, services, lookupd wiring, persistence, replicas, and metrics settings
  remain valid.